### PR TITLE
Try to fix github NuGet pack step

### DIFF
--- a/MSBuild.CompilerCache/MSBuild.CompilerCache.csproj
+++ b/MSBuild.CompilerCache/MSBuild.CompilerCache.csproj
@@ -24,6 +24,7 @@
     </ItemGroup>
     
     <ItemGroup>
+        <None Include="Targets/MSBuild.CompilerCache.targets" Pack="True" PackagePath="build\MSBuild.CompilerCache.targets" />
         <None Include="Targets/*.targets" Pack="True" PackagePath="build\" />
         <None Include="NuGet.README.md">
             <Pack>True</Pack>


### PR DESCRIPTION
For some reason the following correctly includes all `*.targets` files in the NuGet package when running locally:
```
<None Include="Targets/*.targets" Pack="True" PackagePath="build\" />
```
but produces the following warning on GitHub:
```
Warning: /usr/share/dotnet/sdk/7.0.202/Sdks/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets(221,5): warning NU5129: - At least one .targets file was found in 'build/', but 'build/MSBuild.CompilerCache.targets' was not. [/home/runner/work/MSBuild.CompilerCache/MSBuild.CompilerCache/MSBuild.CompilerCache/MSBuild.CompilerCache.csproj]
```

This PR adds the main `.targets` file explicitly and resolves the issue.