### PR TITLE
Set PathMap to map everything to a nonexistent directory so that Rider automatically uses local project sources.

### DIFF
--- a/MSBuild.CompilerCache.Tests/TargetsExtraction.cs
+++ b/MSBuild.CompilerCache.Tests/TargetsExtraction.cs
@@ -328,11 +328,6 @@ public class TargetsExtraction
                 var itemgroup = Name("ItemGroup");
                 var itemGroupElement = new XElement(itemgroup, canCacheCondition);
 
-                var sourcesValue =
-                    relevantAttributes
-                        .Single(x => x.KnownAttr!.Type == AttrType.Sources)
-                        .Value;
-                
                 var inputFiles =
                     relevantAttributes
                         .Where(x => new[]{AttrType.Sources, AttrType.InputFiles}.Contains(x.KnownAttr!.Type))
@@ -386,6 +381,9 @@ public class TargetsExtraction
 
                 compilationTask.AddAfterSelf(startComment, outputsGroup, useOrPopulateCacheElement, endComment);
 
+                var p = compilationTask.Attribute("PathMap");
+                p.Value = "$(MSBuildProjectDirectory)=/__nonexistent__directory__";
+                
                 {
                     using var writer = XmlWriter.Create(cachedPath,
                         new XmlWriterSettings { Indent = true, NewLineOnAttributes = true });

--- a/MSBuild.CompilerCache/Targets/Cached.CoreCompile.6.0.300.CSharp.targets
+++ b/MSBuild.CompilerCache/Targets/Cached.CoreCompile.6.0.300.CSharp.targets
@@ -218,7 +218,7 @@ AND
       Win32Icon="$(ApplicationIcon)"
       Win32Manifest="$(Win32Manifest)"
       Win32Resource="$(Win32Resource)"
-      PathMap="$(PathMap)"
+      PathMap="$(MSBuildProjectDirectory)=/__nonexistent__directory__"
       SourceLink="$(SourceLink)">
       <Output
         TaskParameter="CommandLineArgs"

--- a/MSBuild.CompilerCache/Targets/Cached.CoreCompile.6.0.300.FSharp.targets
+++ b/MSBuild.CompilerCache/Targets/Cached.CoreCompile.6.0.300.FSharp.targets
@@ -172,7 +172,7 @@ AND
       Optimize="$(Optimize)"
       OtherFlags="$(FscOtherFlags)"
       OutputAssembly="@(IntermediateAssembly)"
-      PathMap="$(PathMap)"
+      PathMap="$(MSBuildProjectDirectory)=/__nonexistent__directory__"
       PdbFile="$(PdbFile)"
       Platform="$(PlatformTarget)"
       Prefer32Bit="$(Actual32Bit)"

--- a/MSBuild.CompilerCache/Targets/Cached.CoreCompile.7.0.202.CSharp.targets
+++ b/MSBuild.CompilerCache/Targets/Cached.CoreCompile.7.0.202.CSharp.targets
@@ -219,7 +219,7 @@ AND
       Win32Icon="$(ApplicationIcon)"
       Win32Manifest="$(Win32Manifest)"
       Win32Resource="$(Win32Resource)"
-      PathMap="$(PathMap)"
+      PathMap="$(MSBuildProjectDirectory)=/__nonexistent__directory__"
       SourceLink="$(SourceLink)">
       <Output
         TaskParameter="CommandLineArgs"

--- a/MSBuild.CompilerCache/Targets/Cached.CoreCompile.7.0.202.FSharp.targets
+++ b/MSBuild.CompilerCache/Targets/Cached.CoreCompile.7.0.202.FSharp.targets
@@ -178,7 +178,7 @@ AND
       OtherFlags="$(FscOtherFlags)"
       OutputAssembly="@(IntermediateAssembly)"
       OutputRefAssembly="@(IntermediateRefAssembly)"
-      PathMap="$(PathMap)"
+      PathMap="$(MSBuildProjectDirectory)=/__nonexistent__directory__"
       PdbFile="$(PdbFile)"
       Platform="$(PlatformTarget)"
       Prefer32Bit="$(Actual32Bit)"


### PR DESCRIPTION
Partially fixes https://github.com/safesparrow/MSBuild.CompilerCache/issues/2 .

This guarantees that any source paths seen in the debug symbols point to nonexistent paths and Rider Debugger automatically decides to use current project to look for code.

This means that at least in Rider, debugging should now Just Work when cached dlls are reused.